### PR TITLE
Add content type header for static files

### DIFF
--- a/inc/pre-wp-functions.php
+++ b/inc/pre-wp-functions.php
@@ -7,6 +7,22 @@
  */
 
 /**
+ * List of the mime-types supported by Frontity. 
+ */
+const MIME_TYPES = array(
+	'js' => 'application/javascript',
+  'svg' => 'image/svg+xml',
+  'jpeg' => 'image/jpeg',
+  'jpg' => 'image/jpeg',
+  'png' => 'image/png',
+  'gif' => 'image/gif',
+  'woff' => 'application/font-woff',
+  'woff' => 'application/font-woff2',
+  'ttf' => 'application/x-font-ttf',
+  'eot' => 'application/vnd.ms-fontobject'
+);
+
+/**
  * Cache output before it goes to the browser
  *
  * @param  string $buffer Page HTML.
@@ -115,6 +131,19 @@ function sc_get_url_path() {
 }
 
 /**
+ * Return the correct mime type.
+ * 
+ * @since 1.8
+ * @return string
+ */
+function sc_mime_type_header() {
+	$path_parts = pathinfo(sc_get_url_path());
+	if ( isset( $path_parts['extension'] ) ) {
+		header( 'Content-Type: ' . MIME_TYPES[$path_parts['extension']] );
+	}
+}
+
+/**
  * Optionally serve cache and exit
  *
  * @since 1.0
@@ -134,10 +163,8 @@ function sc_serve_file_cache() {
 
 	header( 'Cache-Control: no-cache' ); // Check back in an hour.
 
-	// Change Content-Type.
-	if ( stripos(strrev($path), strrev('.js/index.html')) === 0 ) {
-		header( 'Content-Type: application/javascript' );
-	}
+	// Send header with the correct Content-Type.
+	sc_mime_type_header();
 
 	if ( ! empty( $modified_time ) && ! empty( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) && strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) === $modified_time ) {
 		if ( function_exists( 'gzencode' ) && ! empty( $GLOBALS['sc_config']['enable_gzip_compression'] ) ) {

--- a/inc/pre-wp-functions.php
+++ b/inc/pre-wp-functions.php
@@ -134,6 +134,11 @@ function sc_serve_file_cache() {
 
 	header( 'Cache-Control: no-cache' ); // Check back in an hour.
 
+	// Change Content-Type.
+	if ( stripos(strrev($path), strrev('.js/index.html')) === 0 ) {
+		header( 'Content-Type: application/javascript' );
+	}
+
 	if ( ! empty( $modified_time ) && ! empty( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) && strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) === $modified_time ) {
 		if ( function_exists( 'gzencode' ) && ! empty( $GLOBALS['sc_config']['enable_gzip_compression'] ) ) {
 			header( 'Content-Encoding: gzip' );


### PR DESCRIPTION
By default simple-cache will send the `text/html` content type. This PR adds support for caching JavaScript files, images and fonts.